### PR TITLE
Fix service newInstance bug: replace hhmmss to HHmmss in moment format

### DIFF
--- a/icc-x-api/crypto/utils.ts
+++ b/icc-x-api/crypto/utils.ts
@@ -342,7 +342,7 @@ export class UtilsClass {
     if (epochOrLongCalendar >= 18000101 && epochOrLongCalendar < 25400000) {
       return moment("" + epochOrLongCalendar, "YYYYMMDD")
     } else if (epochOrLongCalendar >= 18000101000000) {
-      return moment("" + epochOrLongCalendar, "YYYYMMDDhhmmss")
+      return moment("" + epochOrLongCalendar, "YYYYMMDDHHmmss")
     } else {
       return moment(epochOrLongCalendar)
     }

--- a/icc-x-api/icc-contact-x-api.ts
+++ b/icc-x-api/icc-contact-x-api.ts
@@ -774,7 +774,7 @@ export class IccContactXApi extends iccContactApi {
             codes: [],
             tags: [],
             content: {},
-            valueDate: parseInt(moment().format("YYYYMMDDhhmmss"))
+            valueDate: parseInt(moment().format("YYYYMMDDHHmmss"))
           },
           s
         )


### PR DESCRIPTION
In `IccContactXApi.service().newInstance`, the `valueDate` field is formatted incorrectly: the hour part is 12-hour (`hh`) instead of 24-hour (`HH`).

This PR also changes another `hhmmss` format used for parsing in `utils.ts`. This makes no difference, but it helps to be consistent.