### PR TITLE
Mark node-webcrypto-openssl dependency as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,12 +43,14 @@
     "chai": "^4.2.0",
     "husky": "^0.14.3",
     "mocha": "^6.2.0",
-    "node-webcrypto-ossl": "^1.0.48",
     "prettier": "^1.13.5",
     "pretty-quick": "^1.6.0",
     "rimraf": "^2.6.2",
     "ts-node": "^8.3.0",
     "typescript": "^3.8.3"
+  },
+  "optionalDependencies": {
+    "node-webcrypto-ossl": "^1.0.48"
   },
   "scripts": {
     "genhtml": "java -classpath swagger-codegen-cli.jar io.swagger.codegen.SwaggerCodegen generate -i https://backendb.svc.icure.cloud/rest/v1/swagger.json -l html --additional-properties classPrefix=icc -o ./apidocs",


### PR DESCRIPTION
The dependency has no pre-built binaries, which means consumers have to
put the effort in compiling that dependency even though they never use
it.