### PR TITLE
anonymousMedicalInformation sharing and autodelegation

### DIFF
--- a/icc-x-api/icc-contact-x-api.ts
+++ b/icc-x-api/icc-contact-x-api.ts
@@ -147,7 +147,9 @@ export class IccContactXApi extends iccContactApi {
         })
       )
       ;(user.autoDelegations
-        ? (user.autoDelegations.all || []).concat(user.autoDelegations.medicalInformation || [])
+        ? (user.autoDelegations.all || [])
+            .concat(user.autoDelegations.medicalInformation || [])
+            .concat(user.autoDelegations.anonymousMedicalInformation || [])
         : []
       ).forEach(
         delegateId =>

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -24,11 +24,6 @@ import { utils } from "./crypto/utils"
 import { IccCalendarItemXApi } from "./icc-calendar-item-x-api"
 import { decodeBase64 } from "../icc-api/model/ModelHelper"
 
-export enum SharedContent {
-  ALL = "all",
-  ENCRYPTION = "encryption" // for extractor, no delegations, no secret foreign keys, only encryption
-}
-
 // noinspection JSUnusedGlobalSymbols
 export class IccPatientXApi extends iccPatientApi {
   crypto: IccCryptoXApi
@@ -787,8 +782,7 @@ export class IccPatientXApi extends iccPatientApi {
     patId: string,
     ownerId: string,
     delegateIds: Array<string>,
-    delegationTags: { [key: string]: Array<string> },
-    sharedContent: SharedContent = SharedContent.ALL
+    delegationTags: { [key: string]: Array<string> }
   ): Promise<{
     patient: models.PatientDto | null
     statuses: { [key: string]: { success: boolean | null; error: Error | null } }
@@ -826,9 +820,18 @@ export class IccPatientXApi extends iccPatientApi {
       )
     }
 
+    const allTags: string[] = _.uniq(_.flatMap(Object.values(delegationTags)))
+
+    // Determine which keys to share, depending on the delegation tag. For example, anonymousMedicalData only shares encryption keys and no delegations or secret foreign keys.
+    const shareDelegations: boolean = allTags !== ["anonymousMedicalInformation"]
+    const shareEncryptionKeys: boolean = true
+    const shareCryptedForeignKeys: boolean = allTags !== ["anonymousMedicalInformation"]
+
+    // Anonymous sharing, will not change anything to the patient, only its contacts and health elements.
+    const shareAnonymously: boolean = allTags === ["anonymousMedicalInformation"]
+
     return this.hcpartyApi.getHealthcareParty(ownerId).then(hcp => {
       const parentId = hcp.parentId
-      const allTags = _.uniq(_.flatMap(Object.values(delegationTags)))
       const status = {
         contacts: {
           success:
@@ -998,26 +1001,13 @@ export class IccPatientXApi extends iccPatientApi {
                         )
                     ) as Promise<Array<models.CalendarItemDto>>
                   ]).then(([hes, frms, ctcs, ivs, cls, cis]) => {
-                    let cloneDelegations = function(x: models.IcureStubDto) {
-                      return sharedContent === SharedContent.ALL
-                        ? _.clone(x.delegations)
-                        : undefined
-                    }
-                    let cloneCryptedForeignKeys = function(x: models.IcureStubDto) {
-                      return sharedContent === SharedContent.ALL
-                        ? _.clone(x.cryptedForeignKeys)
-                        : undefined
-                    }
-                    let cloneEncryptionKeys = function(x: models.IcureStubDto) {
-                      return [SharedContent.ALL, SharedContent.ENCRYPTION].includes(sharedContent)
-                        ? _.clone(x.encryptionKeys)
-                        : undefined
-                    }
                     let cloneKeysAndDelegations = function(x: models.IcureStubDto) {
                       return {
-                        delegations: cloneDelegations(x),
-                        cryptedForeignKeys: cloneCryptedForeignKeys(x),
-                        encryptionKeys: cloneEncryptionKeys(x)
+                        delegations: shareDelegations ? _.clone(x.delegations) : undefined,
+                        cryptedForeignKeys: shareCryptedForeignKeys
+                          ? _.clone(x.cryptedForeignKeys)
+                          : undefined,
+                        encryptionKeys: shareEncryptionKeys ? _.clone(x.encryptionKeys) : undefined
                       }
                     }
 
@@ -1069,7 +1059,7 @@ export class IccPatientXApi extends iccPatientApi {
                         markerPromise = markerPromise.then(() => {
                           //Share patient
                           //console.log(`share ${patient.id} to ${delegateId}`)
-                          return tags.includes("anonymousMedicalInformation")
+                          return shareAnonymously
                             ? patient
                             : this.crypto
                                 .addDelegationsAndEncryptionKeys(
@@ -1090,7 +1080,7 @@ export class IccPatientXApi extends iccPatientApi {
                                           delSfk: string
                                         ) => {
                                           const patient = await patientPromise
-                                          return tags.includes("anonymousMedicalInformation")
+                                          return shareAnonymously
                                             ? patient
                                             : this.crypto
                                                 .addDelegationsAndEncryptionKeys(

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -823,12 +823,14 @@ export class IccPatientXApi extends iccPatientApi {
     const allTags: string[] = _.uniq(_.flatMap(Object.values(delegationTags)))
 
     // Determine which keys to share, depending on the delegation tag. For example, anonymousMedicalData only shares encryption keys and no delegations or secret foreign keys.
-    const shareDelegations: boolean = allTags !== ["anonymousMedicalInformation"]
+    const shareDelegations: boolean = allTags.some(tag => tag != "anonymousMedicalInformation")
     const shareEncryptionKeys: boolean = true
-    const shareCryptedForeignKeys: boolean = allTags !== ["anonymousMedicalInformation"]
+    const shareCryptedForeignKeys: boolean = allTags.some(
+      tag => tag != "anonymousMedicalInformation"
+    )
 
     // Anonymous sharing, will not change anything to the patient, only its contacts and health elements.
-    const shareAnonymously: boolean = allTags === ["anonymousMedicalInformation"]
+    const shareAnonymously: boolean = allTags.every(tag => tag == "anonymousMedicalInformation")
 
     return this.hcpartyApi.getHealthcareParty(ownerId).then(hcp => {
       const parentId = hcp.parentId

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -831,7 +831,12 @@ export class IccPatientXApi extends iccPatientApi {
       const allTags = _.uniq(_.flatMap(Object.values(delegationTags)))
       const status = {
         contacts: {
-          success: allTags.includes("medicalInformation") || allTags.includes("all") ? false : null,
+          success:
+            allTags.includes("medicalInformation") ||
+            allTags.includes("anonymousMedicalInformation") ||
+            allTags.includes("all")
+              ? false
+              : null,
           error: null,
           modified: 0
         },
@@ -841,7 +846,12 @@ export class IccPatientXApi extends iccPatientApi {
           modified: 0
         },
         healthElements: {
-          success: allTags.includes("medicalInformation") || allTags.includes("all") ? false : null,
+          success:
+            allTags.includes("medicalInformation") ||
+            allTags.includes("anonymousMedicalInformation") ||
+            allTags.includes("all")
+              ? false
+              : null,
           error: null,
           modified: 0
         },

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -24,7 +24,7 @@ import { utils } from "./crypto/utils"
 import { IccCalendarItemXApi } from "./icc-calendar-item-x-api"
 import { decodeBase64 } from "../icc-api/model/ModelHelper"
 
-enum SharedContent {
+export enum SharedContent {
   ALL = "all",
   ENCRYPTION = "encryption" // for extractor, no delegations, no secret foreign keys, only encryption
 }

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -1116,7 +1116,9 @@ export class IccPatientXApi extends iccPatientApi {
                                   return patient
                                 })
                         })
-                        ;(tags.includes("medicalInformation") || tags.includes("all")) &&
+                        ;(tags.includes("medicalInformation") ||
+                          tags.includes("anonymousMedicalInformation") ||
+                          tags.includes("all")) &&
                           (markerPromise = addDelegationsAndKeys(
                             hes,
                             markerPromise,
@@ -1130,7 +1132,9 @@ export class IccPatientXApi extends iccPatientApi {
                             delegateId,
                             patient
                           ))
-                        ;(tags.includes("medicalInformation") || tags.includes("all")) &&
+                        ;(tags.includes("medicalInformation") ||
+                          tags.includes("anonymousMedicalInformation") ||
+                          tags.includes("all")) &&
                           (markerPromise = addDelegationsAndKeys(
                             ctcsStubs,
                             markerPromise,
@@ -1171,7 +1175,9 @@ export class IccPatientXApi extends iccPatientApi {
                         .then(() => {
                           //console.log("scd")
                           return (
-                            ((allTags.includes("medicalInformation") || allTags.includes("all")) &&
+                            ((allTags.includes("medicalInformation") ||
+                              allTags.includes("anonymousMedicalInformation") ||
+                              allTags.includes("all")) &&
                               (ctcsStubs &&
                                 ctcsStubs.length &&
                                 !_.isEqual(oCtcsStubs, ctcsStubs)) &&
@@ -1188,7 +1194,9 @@ export class IccPatientXApi extends iccPatientApi {
                         .then(() => {
                           //console.log("shed")
                           return (
-                            ((allTags.includes("medicalInformation") || allTags.includes("all")) &&
+                            ((allTags.includes("medicalInformation") ||
+                              allTags.includes("anonymousMedicalInformation") ||
+                              allTags.includes("all")) &&
                               (hes && hes.length && !_.isEqual(oHes, hes)) &&
                               this.helementApi
                                 .setHealthElementsDelegations(hes)

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -1069,48 +1069,52 @@ export class IccPatientXApi extends iccPatientApi {
                         markerPromise = markerPromise.then(() => {
                           //Share patient
                           //console.log(`share ${patient.id} to ${delegateId}`)
-                          return this.crypto
-                            .addDelegationsAndEncryptionKeys(
-                              null,
-                              patient,
-                              ownerId,
-                              delegateId,
-                              delSfks[0],
-                              ecKeys[0]
-                            )
-                            .then(async patient => {
-                              if (delSfks.length > 1) {
-                                return delSfks
-                                  .slice(1)
-                                  .reduce(
-                                    async (
-                                      patientPromise: Promise<models.PatientDto>,
-                                      delSfk: string
-                                    ) => {
-                                      const patient = await patientPromise
-                                      return this.crypto
-                                        .addDelegationsAndEncryptionKeys(
-                                          null,
-                                          patient,
-                                          ownerId,
-                                          delegateId,
-                                          delSfk,
-                                          null
-                                        )
-                                        .catch((e: any) => {
-                                          console.log(e)
-                                          return patient
-                                        })
-                                    },
-                                    Promise.resolve(patient)
-                                  )
-                              }
-                              return patient
-                            })
-                            .catch(e => {
-                              console.log(e)
-                              return patient
-                            })
+                          return tags.includes("anonymousMedicalInformation")
+                            ? patient
+                            : this.crypto
+                                .addDelegationsAndEncryptionKeys(
+                                  null,
+                                  patient,
+                                  ownerId,
+                                  delegateId,
+                                  delSfks[0],
+                                  ecKeys[0]
+                                )
+                                .then(async patient => {
+                                  if (delSfks.length > 1) {
+                                    return delSfks
+                                      .slice(1)
+                                      .reduce(
+                                        async (
+                                          patientPromise: Promise<models.PatientDto>,
+                                          delSfk: string
+                                        ) => {
+                                          const patient = await patientPromise
+                                          return tags.includes("anonymousMedicalInformation")
+                                            ? patient
+                                            : this.crypto
+                                                .addDelegationsAndEncryptionKeys(
+                                                  null,
+                                                  patient,
+                                                  ownerId,
+                                                  delegateId,
+                                                  delSfk,
+                                                  null
+                                                )
+                                                .catch((e: any) => {
+                                                  console.log(e)
+                                                  return patient
+                                                })
+                                        },
+                                        Promise.resolve(patient)
+                                      )
+                                  }
+                                  return patient
+                                })
+                                .catch(e => {
+                                  console.log(e)
+                                  return patient
+                                })
                         })
                         ;(tags.includes("medicalInformation") || tags.includes("all")) &&
                           (markerPromise = addDelegationsAndKeys(
@@ -1292,19 +1296,22 @@ export class IccPatientXApi extends iccPatientApi {
                         })
                     })
                   })
-                : this.modifyPatientWithUser(
-                    user,
-                    _.assign(patient, {
-                      delegations: _.assign(
-                        patient.delegations,
-                        delegateIds
-                          .filter(id => !patient.delegations || !patient.delegations[id]) //If there are delegations do not modify
-                          .reduce(
-                            (acc, del: String) => Object.assign(acc, _.fromPairs([[del, []]])),
-                            patient.delegations || {}
+                : (allTags.includes("anonymousMedicalInformation")
+                    ? Promise.resolve(patient)
+                    : this.modifyPatientWithUser(
+                        user,
+                        _.assign(patient, {
+                          delegations: _.assign(
+                            patient.delegations,
+                            delegateIds
+                              .filter(id => !patient.delegations || !patient.delegations[id]) //If there are delegations do not modify
+                              .reduce(
+                                (acc, del: String) => Object.assign(acc, _.fromPairs([[del, []]])),
+                                patient.delegations || {}
+                              )
                           )
+                        })
                       )
-                    })
                   )
                     .then(p => {
                       status.patient.success = true

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -24,6 +24,11 @@ import { utils } from "./crypto/utils"
 import { IccCalendarItemXApi } from "./icc-calendar-item-x-api"
 import { decodeBase64 } from "../icc-api/model/ModelHelper"
 
+enum SharedContent {
+  ALL = "all",
+  ENCRYPTION = "encryption" // for extractor, no delegations, no secret foreign keys, only encryption
+}
+
 // noinspection JSUnusedGlobalSymbols
 export class IccPatientXApi extends iccPatientApi {
   crypto: IccCryptoXApi
@@ -782,7 +787,8 @@ export class IccPatientXApi extends iccPatientApi {
     patId: string,
     ownerId: string,
     delegateIds: Array<string>,
-    delegationTags: { [key: string]: Array<string> }
+    delegationTags: { [key: string]: Array<string> },
+    sharedContent: SharedContent = SharedContent.ALL
   ): Promise<{
     patient: models.PatientDto | null
     statuses: { [key: string]: { success: boolean | null; error: Error | null } }
@@ -982,54 +988,51 @@ export class IccPatientXApi extends iccPatientApi {
                         )
                     ) as Promise<Array<models.CalendarItemDto>>
                   ]).then(([hes, frms, ctcs, ivs, cls, cis]) => {
+                    let cloneDelegations = function(x: models.IcureStubDto) {
+                      return sharedContent === SharedContent.ALL
+                        ? _.clone(x.delegations)
+                        : undefined
+                    }
+                    let cloneCryptedForeignKeys = function(x: models.IcureStubDto) {
+                      return sharedContent === SharedContent.ALL
+                        ? _.clone(x.cryptedForeignKeys)
+                        : undefined
+                    }
+                    let cloneEncryptionKeys = function(x: models.IcureStubDto) {
+                      return [SharedContent.ALL, SharedContent.ENCRYPTION].includes(sharedContent)
+                        ? _.clone(x.encryptionKeys)
+                        : undefined
+                    }
+                    let cloneKeysAndDelegations = function(x: models.IcureStubDto) {
+                      return {
+                        delegations: cloneDelegations(x),
+                        cryptedForeignKeys: cloneCryptedForeignKeys(x),
+                        encryptionKeys: cloneEncryptionKeys(x)
+                      }
+                    }
+
                     const ctcsStubs = ctcs.map(c => ({
                       id: c.id,
                       rev: c.rev,
-                      delegations: _.clone(c.delegations),
-                      cryptedForeignKeys: _.clone(c.cryptedForeignKeys),
-                      encryptionKeys: _.clone(c.encryptionKeys)
+                      ...cloneKeysAndDelegations(c)
                     }))
                     const oHes = hes.map(x =>
-                      _.assign(new IcureStubDto({}), x, {
-                        delegations: _.clone(x.delegations),
-                        cryptedForeignKeys: _.clone(x.cryptedForeignKeys),
-                        encryptionKeys: _.clone(x.encryptionKeys)
-                      })
+                      _.assign(new IcureStubDto({}), x, cloneKeysAndDelegations(x))
                     )
                     const oFrms = frms.map(x =>
-                      _.assign(new IcureStubDto({}), x, {
-                        delegations: _.clone(x.delegations),
-                        cryptedForeignKeys: _.clone(x.cryptedForeignKeys),
-                        encryptionKeys: _.clone(x.encryptionKeys)
-                      })
+                      _.assign(new IcureStubDto({}), x, cloneKeysAndDelegations(x))
                     )
                     const oCtcsStubs = ctcsStubs.map(x =>
-                      _.assign({}, x, {
-                        delegations: _.clone(x.delegations),
-                        cryptedForeignKeys: _.clone(x.cryptedForeignKeys),
-                        encryptionKeys: _.clone(x.encryptionKeys)
-                      })
+                      _.assign({}, x, cloneKeysAndDelegations(x))
                     )
                     const oIvs = ivs.map(x =>
-                      _.assign(new InvoiceDto({}), x, {
-                        delegations: _.clone(x.delegations),
-                        cryptedForeignKeys: _.clone(x.cryptedForeignKeys),
-                        encryptionKeys: _.clone(x.encryptionKeys)
-                      })
+                      _.assign(new InvoiceDto({}), x, cloneKeysAndDelegations(x))
                     )
                     const oCls = cls.map(x =>
-                      _.assign(new ClassificationDto({}), x, {
-                        delegations: _.clone(x.delegations),
-                        cryptedForeignKeys: _.clone(x.cryptedForeignKeys),
-                        encryptionKeys: _.clone(x.encryptionKeys)
-                      })
+                      _.assign(new ClassificationDto({}), x, cloneKeysAndDelegations(x))
                     )
                     const oCis = cis.map(x =>
-                      _.assign(new CalendarItemDto({}), x, {
-                        delegations: _.clone(x.delegations),
-                        cryptedForeignKeys: _.clone(x.cryptedForeignKeys),
-                        encryptionKeys: _.clone(x.encryptionKeys)
-                      })
+                      _.assign(new CalendarItemDto({}), x, cloneKeysAndDelegations(x))
                     )
 
                     const docIds: { [key: string]: number } = {}
@@ -1048,13 +1051,7 @@ export class IccPatientXApi extends iccPatientApi {
                     return retry(() =>
                       this.documentApi.getDocuments(new ListOfIdsDto({ ids: Object.keys(docIds) }))
                     ).then((docs: Array<DocumentDto>) => {
-                      const oDocs = docs.map(x =>
-                        _.assign({}, x, {
-                          delegations: _.clone(x.delegations),
-                          cryptedForeignKeys: _.clone(x.cryptedForeignKeys),
-                          encryptionKeys: _.clone(x.encryptionKeys)
-                        })
-                      )
+                      const oDocs = docs.map(x => _.assign({}, x, cloneKeysAndDelegations(x)))
 
                       let markerPromise: Promise<any> = Promise.resolve(null)
                       delegateIds.forEach(delegateId => {


### PR DESCRIPTION
This provides support for `anonymousMedicalInformation` delegation, which shares only `encryptionKeys` data on contacts and health elements (which are unencrypted for now, hence there is no change in IccHelementXApi).

The same changes have been requested on the Medispring branch (https://github.com/medispring/icc-api/pull/228), which is still based on legacy. This is a rebase of that PR. (No conflicts, one empty commit dropped which was a cherry-pick of a commit already present here.)