### PR TITLE
Fix bug with undefined anonymousMedicalInformation autodelegation

### DIFF
--- a/icc-x-api/icc-contact-x-api.ts
+++ b/icc-x-api/icc-contact-x-api.ts
@@ -116,7 +116,10 @@ export class IccContactXApi extends iccContactApi {
                 })
             ))
         )
-        ;(user.autoDelegations ? user.autoDelegations.anonymousMedicalInformation : []).forEach(
+        ;(user.autoDelegations
+          ? user.autoDelegations.anonymousMedicalInformation || []
+          : []
+        ).forEach(
           delegateId =>
             (promise = promise.then(contact =>
               this.crypto


### PR DESCRIPTION
Unlike other autodelegation types, this one had no fallback to `[]` when undefined while initializing a Contact. This is now fixed.